### PR TITLE
Fix service crash after reboot

### DIFF
--- a/call-monitor-server/src/main/AndroidManifest.xml
+++ b/call-monitor-server/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
             android:name=".service.CallMonitorHttpService"
             android:exported="false" />
         <receiver
-            android:name="com.johnseremba.call.monitor.server.service.BootCompletedReceiver"
+            android:name="com.johnseremba.call.monitor.server.receiver.BootCompletedReceiver"
             android:enabled="true"
             android:exported="true">
             <intent-filter>

--- a/call-monitor-server/src/main/kotlin/com/johnseremba/call/monitor/server/receiver/BootCompletedReceiver.kt
+++ b/call-monitor-server/src/main/kotlin/com/johnseremba/call/monitor/server/receiver/BootCompletedReceiver.kt
@@ -1,9 +1,10 @@
-package com.johnseremba.call.monitor.server.service
+package com.johnseremba.call.monitor.server.receiver
 
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import com.johnseremba.call.monitor.server.service.CallMonitorHttpService
 
 internal class BootCompletedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {


### PR DESCRIPTION
The http service would unreliably crash on device restart due to incomplete koin initialization.
This attempts to fix the issue by removing the unnecessary 'isRunning' in the onCreate method, to ensure that the HttpService always gets properly initialized when the service is first created.
This also introduces a courotineScope with which to execute the http service in.
The 'BootCompletedReceiver' class is moved to the 'receiver' package for better visibility.